### PR TITLE
fix: align words from nlp model & whisper output words

### DIFF
--- a/local/e2e_stt/nlp_models.py
+++ b/local/e2e_stt/nlp_models.py
@@ -146,7 +146,9 @@ class NlpModel(object):
         
         return nlp_feats
        
-  
+    def get_doc(self, text):
+        doc = self.nlp_tokenize(text)
+        return doc
 if __name__ == '__main__':
     text = "I agree with the statement. We had many holidays, which is longer than others. Most of us were planning to find a part-time job in order to kill the boring time while we got the news. So it was the same with me.  My friends had work experience and had a more independent life. They are willing to share their interesting work experience with me. In their work life, they met many difficulties. They would try to do something only they are. Different kinds of setbacks made them more strong and going easy on everything afterwards.  I feel the sound of a shampoo."
 

--- a/local/plot_evaluation_results.py
+++ b/local/plot_evaluation_results.py
@@ -64,8 +64,13 @@ def flatten_words_with_pos(error_cases, nlp_model):
     rows = []
     for utt in error_cases:
         words = " ".join([w["word"] for w in utt["words"]])
-        vp_feats = nlp_model.vocab_profile_feats(words)
-        pos_feats = vp_feats["pos_list"]
+        doc = nlp_model.get_doc(words)
+
+        # Workaround: Remove Punctuation and some particles from pos_feats so that pos_feats align with utt["words"]
+        words = [word for sent in doc.sentences for word in sent.words]
+        words = list(filter(lambda x: x.upos != "PUNCT" and x.text != "n't" and x.text[0] != "'", words))
+        pos_feats = [word.upos for word in words]
+        assert len(pos_feats) == len(utt["words"]), f"Length mismatch: POS {len(pos_feats)} vs WORDS {len(utt['words'])}"
 
         for i, word in enumerate(utt["words"]):
             rows.append({


### PR DESCRIPTION
This PR proposes a workaround to align the word sequence from the NLP model and Whisper.
By removing
- PUNCT e.g. ".", ",", "!", and more
- Words that start with apostrophe, e.g., "n't", "'ll", and more