### PR TITLE
Add multi-corpus evaluation, EmphAssess adapters, and download pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,64 @@ If you use ***WhiStress*** in your work, please cite our paper:
     url={https://arxiv.org/abs/2505.19103}, 
 }
 ```
+
+## Multi-corpus evaluation
+
+The evaluation pipeline supports `tinystress`, `stresstest`, `stresspresso`, and
+`emphassess`. Stage 0 downloads and validates them without changing the Stage 1
+training data or training procedure:
+
+```bash
+python local/download_corpora.py \
+  --data_root data/raw \
+  --corpora tinystress stresstest stresspresso emphassess
+
+# Download, train, test, evaluate, and plot.
+./run.sh --stage 0 --stop_stage 4 --gpuid 0 --train_conf conf/baseline.json
+
+# Reuse downloaded data and an existing checkpoint; run Stage 2 and Stage 3 only.
+./run.sh --stage 2 --stop_stage 3 --gpuid 0 --train_conf conf/baseline.json
+
+# Evaluate a subset (a quoted, space-separated parse_options.sh value).
+./run.sh --stage 2 --stop_stage 3 --test_corpora "stresstest emphassess"
+```
+
+TinyStress-15K already supplies `transcription`, audio, and
+`emphasis_indices`. StressTest and StressPresso supply interpretation-specific
+IDs and nested `stress_pattern` labels; their binary labels are validated during
+adaptation. EmphAssess supplies token lists and `gold_emphasis`; its original
+16-kHz source WAV (not an output of the official speech-to-speech emphasis
+transfer pipeline) is evaluated directly. All adapters produce this canonical
+shape before the existing preprocessing runs:
+
+```python
+{
+    "id": str,
+    "transcription": str,
+    "audio": {"array": ..., "sampling_rate": int, "path": str | None},
+    "emphasis_indices": list[int],
+    "source_dataset": str,
+}
+```
+
+For EmphAssess, standalone punctuation is removed while apostrophes inside words
+are retained, and emphasis indices are remapped. The 12 rows whose emphasis
+points to standalone punctuation are rejected as invalid (3,652 original, 3,640
+retained); labels are never shifted to a neighboring word. EmphAssess is
+distributed under **CC BY-NC 4.0**; review `LICENSE.md` in the downloaded corpus
+before use.
+
+Stage 2 reports teacher-forced **Whisper token-level** metrics. Stage 3 preserves
+the inference evaluation's merged **word-level** metrics, both with and without
+ground-truth transcription. Interpret without-transcription results together
+with their separately reported coverage because word-length mismatches remain
+skipped rather than being force-aligned.
+
+Corpus-specific outputs are written to:
+
+```text
+exp/<config>/test/tinystress/
+exp/<config>/test/stresstest/
+exp/<config>/test/stresspresso/
+exp/<config>/test/emphassess/
+```

--- a/corpora.py
+++ b/corpora.py
@@ -1,0 +1,213 @@
+"""Corpus adapters for WhiStress evaluation datasets."""
+
+from __future__ import annotations
+
+import json
+import string
+import wave
+from array import array
+from pathlib import Path
+from typing import Any
+
+SUPPORTED_CORPORA = ("tinystress", "stresstest", "stresspresso", "emphassess")
+
+
+class InvalidEmphasisError(ValueError):
+    """An emphasis label points at a standalone punctuation token."""
+
+
+def is_standalone_punctuation(token: str) -> bool:
+    return bool(token) and all(character in string.punctuation for character in token)
+
+
+def validate_canonical_sample(sample: dict[str, Any]) -> dict[str, Any]:
+    words = sample["transcription"].strip().split()
+    if not words:
+        raise ValueError(f"Sample {sample.get('id')!r} has an empty transcription")
+    invalid = [index for index in sample["emphasis_indices"] if not 0 <= index < len(words)]
+    if invalid:
+        raise ValueError(
+            f"Sample {sample.get('id')!r} has out-of-range emphasis indices {invalid} "
+            f"for {len(words)} words"
+        )
+    return sample
+
+
+def compute_stress_binary(transcription: str, emphasis_indices: list[int]) -> list[int]:
+    """Build the word-level labels consumed by ``StressDataset.preprocess``."""
+    words = transcription.strip().split()
+    return [1 if index in emphasis_indices else 0 for index in range(len(words))]
+
+
+def _canonical_audio(audio: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "array": audio["array"],
+        "sampling_rate": int(audio["sampling_rate"]),
+        "path": audio.get("path"),
+    }
+
+
+def adapt_tinystress_example(example: dict[str, Any]) -> dict[str, Any]:
+    return validate_canonical_sample({
+        "id": str(example["id"]),
+        "transcription": example["transcription"],
+        "audio": _canonical_audio(example["audio"]),
+        "emphasis_indices": list(example["emphasis_indices"]),
+        "source_dataset": "tinystress",
+    })
+
+
+def adapt_stress_benchmark_example(
+    example: dict[str, Any], source_dataset: str
+) -> dict[str, Any]:
+    if source_dataset not in ("stresstest", "stresspresso"):
+        raise ValueError(f"Unsupported stress benchmark: {source_dataset}")
+    pattern = example["stress_pattern"]
+    sample = validate_canonical_sample({
+        "id": str(example["interpretation_id"]),
+        "transcription": example["transcription"],
+        "audio": _canonical_audio(example["audio"]),
+        "emphasis_indices": list(pattern["indices"]),
+        "source_dataset": source_dataset,
+    })
+    expected_binary = compute_stress_binary(
+        sample["transcription"], sample["emphasis_indices"]
+    )
+    if list(pattern["binary"]) != expected_binary:
+        raise ValueError(f"Stress-pattern binary mismatch for sample {sample['id']}")
+    return sample
+
+
+def _read_wav(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Missing EmphAssess audio: {path}")
+    with wave.open(str(path), "rb") as wav_file:
+        channels = wav_file.getnchannels()
+        sample_width = wav_file.getsampwidth()
+        sampling_rate = wav_file.getframerate()
+        frames = wav_file.readframes(wav_file.getnframes())
+    if channels != 1 or sample_width != 2 or sampling_rate != 16000:
+        raise ValueError(f"Expected 16 kHz mono PCM16 WAV: {path}")
+    samples = array("h")
+    samples.frombytes(frames)
+    if samples.itemsize != sample_width:
+        raise ValueError(f"Unsupported PCM sample width in WAV: {path}")
+    return {
+        "array": [sample / 32768.0 for sample in samples],
+        "sampling_rate": sampling_rate,
+        "path": str(path),
+    }
+
+
+def adapt_emphassess_row(row: dict[str, Any], emphassess_root: str | Path) -> dict[str, Any]:
+    tokens = list(row["src_sentence"])
+    emphasis = list(row["gold_emphasis"])
+    if any(index < 0 or index >= len(tokens) for index in emphasis):
+        raise ValueError(f"EmphAssess row {row.get('id')!r} has an invalid original index")
+    if any(is_standalone_punctuation(tokens[index]) for index in emphasis):
+        raise InvalidEmphasisError(
+            f"EmphAssess row {row['id']} emphasizes standalone punctuation"
+        )
+
+    old_to_new: dict[int, int] = {}
+    words = []
+    for old_index, token in enumerate(tokens):
+        if not is_standalone_punctuation(token):
+            old_to_new[old_index] = len(words)
+            words.append(token)
+    audio_path = Path(emphassess_root) / f"{row['id']}.wav"
+    return validate_canonical_sample({
+        "id": str(row["id"]),
+        "transcription": " ".join(words),
+        "audio": _read_wav(audio_path),
+        "emphasis_indices": [old_to_new[index] for index in emphasis],
+        "source_dataset": "emphassess",
+        "voice": row.get("voice"),
+    })
+
+
+def _read_emphassess_rows(root: Path) -> tuple[list[dict[str, Any]], int]:
+    annotation_path = root / "gold_df.json"
+    if not annotation_path.is_file():
+        raise FileNotFoundError(f"Missing EmphAssess annotations: {annotation_path}")
+    rows = [json.loads(line) for line in annotation_path.read_text().splitlines() if line.strip()]
+    ids = [row["id"] for row in rows]
+    if len(ids) != len(set(ids)):
+        raise ValueError("Duplicate EmphAssess annotation ID detected")
+    samples = []
+    filtered = 0
+    for row in rows:
+        try:
+            samples.append(adapt_emphassess_row(row, root))
+        except InvalidEmphasisError:
+            filtered += 1
+    return samples, filtered
+
+
+def load_corpus(corpus: str, split: str = "test", data_root: str | Path = "data/raw"):
+    from datasets import Dataset, load_from_disk
+
+    if corpus not in SUPPORTED_CORPORA:
+        raise ValueError(f"Unsupported corpus {corpus!r}; choose from {SUPPORTED_CORPORA}")
+    root = Path(data_root) / corpus
+    if corpus == "emphassess":
+        # A complete official download must never be evaluated with silently
+        # changed annotation, audio, or filtering counts.
+        validate_emphassess_directory(root)
+        samples, filtered = _read_emphassess_rows(root)
+        dataset = Dataset.from_list(samples)
+        dataset.info.description = json.dumps({
+            "num_original_samples": len(samples) + filtered,
+            "num_filtered_invalid_emphasis": filtered,
+            "num_retained_samples": len(samples),
+        })
+        return dataset
+
+    stored = load_from_disk(str(root))
+    raw = stored[split] if hasattr(stored, "keys") and split in stored else stored
+    if corpus == "tinystress":
+        return raw.map(adapt_tinystress_example, remove_columns=raw.column_names)
+    return raw.map(
+        lambda example: adapt_stress_benchmark_example(example, corpus),
+        remove_columns=raw.column_names,
+    )
+
+
+def validate_emphassess_directory(root: str | Path, require_official_counts: bool = True) -> dict[str, int | str]:
+    root = Path(root)
+    rows = [json.loads(line) for line in (root / "gold_df.json").read_text().splitlines() if line.strip()]
+    ids = [str(row["id"]) for row in rows]
+    if len(ids) != len(set(ids)):
+        raise ValueError("Duplicate EmphAssess annotation ID detected")
+    wav_stems = {path.stem for path in root.glob("*.wav")}
+    if set(ids) != wav_stems:
+        missing = sorted(set(ids) - wav_stems)
+        orphaned = sorted(wav_stems - set(ids))
+        raise ValueError(f"EmphAssess audio mismatch: missing={missing[:5]}, orphaned={orphaned[:5]}")
+    for wav_path in root.glob("*.wav"):
+        with wave.open(str(wav_path), "rb") as wav_file:
+            audio_format = (
+                wav_file.getframerate(),
+                wav_file.getnchannels(),
+                wav_file.getsampwidth(),
+                wav_file.getcomptype(),
+            )
+        if audio_format != (16000, 1, 2, "NONE"):
+            raise ValueError(
+                f"Expected 16 kHz mono PCM16 WAV, got {audio_format}: {wav_path}"
+            )
+    invalid = sum(
+        any(0 <= index < len(row["src_sentence"]) and is_standalone_punctuation(row["src_sentence"][index])
+            for index in row["gold_emphasis"])
+        for row in rows
+    )
+    manifest = {
+        "dataset": "emphassess",
+        "num_annotations": len(rows),
+        "num_audio_files": len(wav_stems),
+        "num_filtered_invalid_emphasis": invalid,
+        "num_retained_samples": len(rows) - invalid,
+    }
+    if require_official_counts and (len(rows), len(wav_stems), invalid, len(rows) - invalid) != (3652, 3652, 12, 3640):
+        raise ValueError(f"Unexpected EmphAssess counts: {manifest}")
+    return manifest

--- a/evaluation_example.py
+++ b/evaluation_example.py
@@ -8,6 +8,9 @@ import pyphen
 from utils import StressDataset, MyCollate
 from torch.utils.data import DataLoader
 import argparse
+import json
+
+from corpora import SUPPORTED_CORPORA, compute_stress_binary, load_corpus
 
 dic = pyphen.Pyphen(lang='en')
 
@@ -67,6 +70,7 @@ def calculate_metrics_on_dataset(dataset, whistress_client, with_transcription=T
     predictions_psd = []
     references_psd = []
     error_cases = []
+    num_skipped = 0
 
     for sample in tqdm(dataset):
         #gt_stresses = sample['stress_pattern']['binary']
@@ -102,6 +106,7 @@ def calculate_metrics_on_dataset(dataset, whistress_client, with_transcription=T
             print(scored)
             print(pred_stresses, len(pred_stresses))
             print(gt_stresses, len(gt_stresses))    
+            num_skipped += 1
             continue
         
         words = sample["transcription"].strip().split()
@@ -142,6 +147,8 @@ def calculate_metrics_on_dataset(dataset, whistress_client, with_transcription=T
             references_psd.extend(list(phone_labels_head))
         
         error_cases.append({
+            "id": str(sample["id"]),
+            "source_dataset": sample.get("source_dataset", "unknown"),
             "transcription": sample["transcription"],
             "utt_len": utt_len,
             "utt_duration": duration_sec,
@@ -154,13 +161,17 @@ def calculate_metrics_on_dataset(dataset, whistress_client, with_transcription=T
         predictions.extend(pred_stresses)
         references.extend(gt_stresses)
 
-    metrics = compute_prf_metrics(predictions, references, average="binary")
-    metrics_psd = compute_prf_metrics(predictions_psd, references_psd, average="binary")
-    return metrics, metrics_psd, error_cases
-
-def compute_stress_binary(transcription: str, emphasis_indices: list[int]) -> list[int]:
-    words = transcription.strip().split()
-    return [1 if i in emphasis_indices else 0 for i in range(len(words))]
+    metrics = compute_prf_metrics(predictions, references, average="binary") if references else None
+    metrics_psd = compute_prf_metrics(predictions_psd, references_psd, average="binary") if references_psd else None
+    num_samples = len(dataset)
+    coverage = {
+        "num_samples": num_samples,
+        "num_evaluated": num_samples - num_skipped,
+        "num_skipped": num_skipped,
+        "coverage_rate": (num_samples - num_skipped) / num_samples if num_samples else 0.0,
+        "skip_reasons": {"word_length_mismatch": num_skipped},
+    }
+    return metrics, metrics_psd, error_cases, coverage
 
 def add_stress_pattern(example):
     binary = compute_stress_binary(example["transcription"], example["emphasis_indices"])
@@ -169,16 +180,17 @@ def add_stress_pattern(example):
 
 
 if __name__ == "__main__":
-    from datasets import load_dataset
-    import json
     parser = argparse.ArgumentParser()
     parser.add_argument("--metadata_fn", type=str)
     parser.add_argument("--results_dir", type=str)
+    parser.add_argument("--corpus", choices=SUPPORTED_CORPORA, default="tinystress")
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--data_root", type=Path, default=Path("data"))
     args = parser.parse_args()
     # Load your dataset, replace with the actual dataset you are using
-    dataset_name = "slprl/TinyStress-15K"  # Example dataset name, change as needed
-    dataset = load_dataset(dataset_name)
-    split_name = 'test' 
+    dataset_name = args.corpus
+    split_name = args.split
+    raw_dataset = load_corpus(args.corpus, args.split, args.data_root / "raw")
     
     print(f"Evaluating WhiStress on {dataset_name} for split {split_name}...")
     if args.metadata_fn is not None:
@@ -194,16 +206,33 @@ if __name__ == "__main__":
     #dataset[split_name] = dataset[split_name].map(add_stress_pattern, num_proc=4)
     #metrics, error_cases = calculate_metrics_on_dataset(dataset=dataset[split_name], whistress_client=whistress_client)
     #metrics_wot, error_cases_wot = calculate_metrics_on_dataset(dataset=dataset[split_name], whistress_client=whistress_client, with_transcription=False)
-    dataset[split_name] = StressDataset(hf_dataset_or_path=dataset[split_name], model=model, processed_dir=f"data/{split_name}")
-    metrics, metrics_wsd, error_cases = calculate_metrics_on_dataset(dataset=dataset[split_name], whistress_client=whistress_client, device=device)
-    metrics_wot, _, error_cases_wot = calculate_metrics_on_dataset(dataset=dataset[split_name], whistress_client=whistress_client, with_transcription=False, device=device)
+    processed_dir = args.data_root / "processed" / args.corpus / args.split
+    dataset = StressDataset(hf_dataset_or_path=raw_dataset, model=model, processed_dir=str(processed_dir))
+    metrics, metrics_wsd, error_cases, coverage = calculate_metrics_on_dataset(dataset=dataset, whistress_client=whistress_client, device=device)
+    metrics_wot, _, error_cases_wot, coverage_wot = calculate_metrics_on_dataset(dataset=dataset, whistress_client=whistress_client, with_transcription=False, device=device)
+
+    corpus_stats = {
+        "num_original_samples": len(raw_dataset),
+        "num_filtered_invalid_emphasis": 0,
+        "num_retained_samples": len(raw_dataset),
+    }
+    if args.corpus == "emphassess":
+        corpus_stats = json.loads(raw_dataset.info.description)
 
     results = {
         "dataset": dataset_name,
         "split": split_name,
+        "num_original_samples": corpus_stats["num_original_samples"],
+        "num_filtered_invalid_emphasis": corpus_stats["num_filtered_invalid_emphasis"],
+        "num_samples": len(raw_dataset),
         "metrics": metrics,
-        "metrics_wsd": metrics_wsd,
-        "metrics_wot": metrics_wot
+        "metrics_wsd": ({
+            **metrics_wsd,
+            "label_source": "cmudict_g2p_lexical_stress",
+        } if metrics_wsd is not None else None),
+        "metrics_wot": metrics_wot,
+        "coverage": coverage,
+        "coverage_wot": coverage_wot,
     }
 
     # Save or log the metrics as needed

--- a/local/download_corpora.py
+++ b/local/download_corpora.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Download and validate the evaluation corpora."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from corpora import SUPPORTED_CORPORA, validate_emphassess_directory
+
+
+HF_DATASETS = {
+    "tinystress": "slprl/TinyStress-15K",
+    "stresstest": "slprl/StressTest",
+    "stresspresso": "slprl/StressPresso",
+}
+EMPHASSESS_URL = "https://dl.fbaipublicfiles.com/speech_expressivity_evaluation/EmphAssess/EmphAssess_Dataset.tar.gz"
+
+
+def _safe_extract(archive: tarfile.TarFile, destination: Path) -> None:
+    destination = destination.resolve()
+    for member in archive.getmembers():
+        target = (destination / member.name).resolve()
+        if target != destination and destination not in target.parents:
+            raise ValueError(f"Unsafe path in archive: {member.name}")
+        if member.issym() or member.islnk():
+            raise ValueError(f"Links are not allowed in archive: {member.name}")
+    archive.extractall(destination)
+
+
+def download_hf_corpus(corpus: str, data_root: Path, force: bool) -> None:
+    from datasets import load_dataset, load_from_disk
+
+    destination = data_root / corpus
+    if destination.exists() and not force:
+        load_from_disk(str(destination))
+        print(f"{corpus}: existing validated download; skipping")
+        return
+    if force:
+        shutil.rmtree(destination, ignore_errors=True)
+    dataset = load_dataset(HF_DATASETS[corpus])
+    temporary = Path(tempfile.mkdtemp(prefix=f".{corpus}.", dir=data_root))
+    try:
+        dataset.save_to_disk(str(temporary))
+        temporary.replace(destination)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    print(f"{corpus}: downloaded {HF_DATASETS[corpus]}")
+
+
+def download_emphassess(data_root: Path, force: bool) -> None:
+    destination = data_root / "emphassess"
+    if destination.exists() and not force:
+        manifest = validate_emphassess_directory(destination)
+        print("emphassess: existing validated download; skipping")
+        _print_emphassess_counts(manifest)
+        return
+    if force:
+        shutil.rmtree(destination, ignore_errors=True)
+
+    work = Path(tempfile.mkdtemp(prefix=".emphassess.", dir=data_root))
+    archive_path = work / "EmphAssess_Dataset.tar.gz.part"
+    try:
+        urllib.request.urlretrieve(EMPHASSESS_URL, archive_path)
+        final_archive = work / "EmphAssess_Dataset.tar.gz"
+        archive_path.replace(final_archive)
+        with tarfile.open(final_archive, "r:gz") as archive:
+            _safe_extract(archive, work)
+        # The official archive is flat; tolerate a single wrapper only to locate
+        # the files, then normalize the persisted layout to the documented flat form.
+        annotation = next(work.rglob("gold_df.json"), None)
+        if annotation is None:
+            raise FileNotFoundError("gold_df.json was not found after extraction")
+        source_root = annotation.parent
+        normalized = Path(tempfile.mkdtemp(prefix=".emphassess.normalized.", dir=data_root))
+        for path in source_root.iterdir():
+            if path.is_file() and path != final_archive:
+                shutil.move(str(path), normalized / path.name)
+        shutil.move(str(final_archive), normalized / final_archive.name)
+        manifest = validate_emphassess_directory(normalized)
+        (normalized / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+        normalized.replace(destination)
+    except Exception:
+        shutil.rmtree(work, ignore_errors=True)
+        if "normalized" in locals():
+            shutil.rmtree(normalized, ignore_errors=True)
+        raise
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+    _print_emphassess_counts(manifest)
+
+
+def _print_emphassess_counts(manifest: dict) -> None:
+    print(f"EmphAssess annotations: {manifest['num_annotations']}")
+    print(f"EmphAssess WAV files: {manifest['num_audio_files']}")
+    print(f"Invalid punctuation-emphasis rows: {manifest['num_filtered_invalid_emphasis']}")
+    print(f"Retained EmphAssess rows: {manifest['num_retained_samples']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data_root", type=Path, default=Path("data/raw"))
+    parser.add_argument("--corpora", nargs="+", choices=SUPPORTED_CORPORA, default=list(SUPPORTED_CORPORA))
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+    args.data_root.mkdir(parents=True, exist_ok=True)
+    for corpus in args.corpora:
+        if corpus == "emphassess":
+            download_emphassess(args.data_root, args.force)
+        else:
+            download_hf_corpus(corpus, args.data_root, args.force)
+
+
+if __name__ == "__main__":
+    main()

--- a/run.sh
+++ b/run.sh
@@ -7,56 +7,67 @@ stage=0
 stop_stage=1000
 train_conf=conf/baseline.json
 gpuid=0
+data_root=data
+test_corpora="tinystress stresstest stresspresso emphassess"
+force_download=false
 
 . ./local/parse_options.sh
 . ./path.sh
 
-exp_dir=exp/$(basename -s .json $train_conf)
+exp_dir="exp/$(basename -s .json "$train_conf")"
 
-if [ $stage -le 1 ] && [ $stop_stage -ge 1 ]; then
-
-    if [ ! -f $exp_dir/.done ]; then
-        CUDA_VISIBLE_DEVICES=$gpuid \
-            python train.py \
-                --train_conf $train_conf \
-                --exp_dir $exp_dir
+if [ "$stage" -le 0 ] && [ "$stop_stage" -ge 0 ]; then
+    download_args=(
+        --data_root "$data_root/raw"
+        --corpora $test_corpora
+    )
+    if [ "$force_download" = true ]; then
+        download_args+=(--force)
     fi
-    touch $exp_dir/.done
+    python local/download_corpora.py "${download_args[@]}"
 fi
 
-if [ $stage -le 2 ] && [ $stop_stage -ge 2 ]; then
-    results_dir=$exp_dir/test
+if [ "$stage" -le 1 ] && [ "$stop_stage" -ge 1 ]; then
 
-    mkdir -p $results_dir
-
-    CUDA_VISIBLE_DEVICES=$gpuid \
-        python test.py \
-            --pretrained_ckpt_dir $exp_dir/best \
-            --batch_size 1 \
-            --exp_dir $exp_dir > $results_dir/test.log
+    if [ ! -f "$exp_dir/.done" ]; then
+        CUDA_VISIBLE_DEVICES="$gpuid" \
+            python train.py \
+                --train_conf "$train_conf" \
+                --exp_dir "$exp_dir"
+    fi
+    touch "$exp_dir/.done"
 fi
 
-if [ $stage -le 3 ] && [ $stop_stage -ge 3 ]; then
-    metadata_fn=$exp_dir/best/metadata.json
-    results_dir=$exp_dir/test
-
-    echo "CUDA_VISIBLE_DEVICES=$gpuid python evaluation_example.py --metadata_fn $metadata_fn --results_dir $results_dir"
-
-    CUDA_VISIBLE_DEVICES=$gpuid \
-        python evaluation_example.py \
-            --metadata_fn $metadata_fn \
-            --results_dir $results_dir
-    
-    cat $results_dir/whistress_evaluation.json
-    
+if [ "$stage" -le 2 ] && [ "$stop_stage" -ge 2 ]; then
+    for corpus in $test_corpora; do
+        results_dir="$exp_dir/test/$corpus"
+        mkdir -p "$results_dir"
+        CUDA_VISIBLE_DEVICES="$gpuid" python test.py \
+            --pretrained_ckpt_dir "$exp_dir/best" --batch_size 1 \
+            --exp_dir "$exp_dir" --corpus "$corpus" --split test \
+            --data_root "$data_root" --results_dir "$results_dir" \
+            > "$results_dir/stage2.log"
+    done
 fi
 
-if [ $stage -le 4 ] && [ $stop_stage -ge 4 ]; then
-    metadata_fn=$exp_dir/best/metadata.json
-    results_dir=$exp_dir/test
-    
-    python local/plot_evaluation_results.py \
-        --error_case_path $results_dir/whistress_error_analysis.json \
-        --save_fig_dir $results_dir/imgs
+if [ "$stage" -le 3 ] && [ "$stop_stage" -ge 3 ]; then
+    metadata_fn="$exp_dir/best/metadata.json"
+    for corpus in $test_corpora; do
+        results_dir="$exp_dir/test/$corpus"
+        mkdir -p "$results_dir"
+        CUDA_VISIBLE_DEVICES="$gpuid" python evaluation_example.py \
+            --metadata_fn "$metadata_fn" --corpus "$corpus" --split test \
+            --data_root "$data_root" --results_dir "$results_dir" \
+            > "$results_dir/stage3.log"
+        cat "$results_dir/whistress_evaluation.json"
+    done
 fi
 
+if [ "$stage" -le 4 ] && [ "$stop_stage" -ge 4 ]; then
+    for corpus in $test_corpora; do
+        results_dir="$exp_dir/test/$corpus"
+        python local/plot_evaluation_results.py \
+            --error_case_path "$results_dir/whistress_error_analysis.json" \
+            --save_fig_dir "$results_dir/imgs"
+    done
+fi

--- a/test.py
+++ b/test.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass, field
 
 import torch
 from torch.utils.data import DataLoader
-from datasets import load_dataset
 from transformers import WhisperProcessor, WhisperTokenizerFast, WhisperConfig, AdamW
 from tqdm import tqdm
 import evaluate
@@ -20,6 +19,7 @@ from whistress.model.model import WhiStress, WhiStressPhn, WhiStressPhnIa
 
 from utils import StressDataset, MyCollate
 from metrics import compute_prf_metrics
+from corpora import SUPPORTED_CORPORA, load_corpus
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -27,6 +27,10 @@ if __name__ == "__main__":
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument('--seed', type=int, default=66)
     parser.add_argument("--exp_dir", type=str, default="./exp/baseline")
+    parser.add_argument("--corpus", choices=SUPPORTED_CORPORA, default="tinystress")
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--data_root", type=Path, default=Path("data"))
+    parser.add_argument("--results_dir", type=Path, default=None)
     args = parser.parse_args()
 
     exp_dir = Path(args.exp_dir)
@@ -39,9 +43,10 @@ if __name__ == "__main__":
     
     model = get_loaded_model(device=device, metadata=metadata)
 
-    dataset = load_dataset("slprl/TinyStress-15K")
+    dataset = load_corpus(args.corpus, args.split, args.data_root / "raw")
+    processed_dir = args.data_root / "processed" / args.corpus / args.split
     data_collate = MyCollate(processor=model.processor)
-    val_loader = DataLoader(StressDataset(hf_dataset_or_path=dataset["test"], model=model, processed_dir="data/test"), batch_size=args.batch_size, collate_fn=data_collate)
+    val_loader = DataLoader(StressDataset(hf_dataset_or_path=dataset, model=model, processed_dir=str(processed_dir)), batch_size=args.batch_size, collate_fn=data_collate)
 
     best_f1, best_epoch, metrics_log = -1.0, -1, []
     
@@ -82,3 +87,17 @@ if __name__ == "__main__":
 
     prf = compute_prf_metrics(all_preds, all_labels)
     print(f"Precision: {prf['precision']:.4f}, Recall: {prf['recall']:.4f}, F1: {prf['f1']:.4f}")
+    results_dir = args.results_dir or exp_dir / "test" / args.corpus
+    results_dir.mkdir(parents=True, exist_ok=True)
+    metrics = {
+        "dataset": args.corpus,
+        "split": args.split,
+        "evaluation_stage": 2,
+        "evaluation_mode": "teacher_forced",
+        "metric_level": "whisper_token",
+        "num_samples": len(dataset),
+        "num_labeled_tokens": len(all_labels),
+        **prf,
+    }
+    with (results_dir / "stage2_metrics.json").open("w") as file:
+        json.dump(metrics, file, indent=2)

--- a/tests/test_corpora.py
+++ b/tests/test_corpora.py
@@ -1,0 +1,113 @@
+import json
+import wave
+
+import pytest
+
+from corpora import (
+    InvalidEmphasisError,
+    adapt_emphassess_row,
+    adapt_stress_benchmark_example,
+    adapt_tinystress_example,
+    compute_stress_binary,
+    validate_canonical_sample,
+    validate_emphassess_directory,
+)
+
+
+def write_wav(path):
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16000)
+        wav_file.writeframes(b"\x00\x00" * 16)
+
+
+def audio():
+    return {"array": [0.0] * 4, "sampling_rate": 16000, "path": None}
+
+
+def benchmark():
+    return {
+        "transcription_id": "sentence",
+        "interpretation_id": "interpretation",
+        "transcription": "we really agree",
+        "audio": audio(),
+        "stress_pattern": {"binary": [0, 1, 0], "indices": [1], "words": ["really"]},
+    }
+
+
+def test_tinystress_adapter():
+    sample = adapt_tinystress_example({"id": 7, "transcription": "hello world", "audio": audio(), "emphasis_indices": [1]})
+    assert sample["id"] == "7" and sample["source_dataset"] == "tinystress"
+
+
+def test_stresstest_adapter():
+    sample = adapt_stress_benchmark_example(benchmark(), "stresstest")
+    assert sample["id"] == "interpretation" and sample["emphasis_indices"] == [1]
+
+
+def test_stresspresso_adapter():
+    example = benchmark()
+    example["metadata"] = {"speaker_id": "speaker"}
+    assert adapt_stress_benchmark_example(example, "stresspresso")["source_dataset"] == "stresspresso"
+
+
+def test_stress_benchmark_binary_consistency():
+    example = benchmark()
+    example["stress_pattern"]["binary"] = [1, 0, 0]
+    with pytest.raises(ValueError, match="interpretation"):
+        adapt_stress_benchmark_example(example, "stresstest")
+
+
+def test_emphassess_punctuation_remapping(tmp_path):
+    write_wav(tmp_path / "item.wav")
+    sample = adapt_emphassess_row({"id": "item", "src_sentence": ["hello", ",", "world", "!"], "gold_emphasis": [2], "voice": "v"}, tmp_path)
+    assert sample["transcription"] == "hello world" and sample["emphasis_indices"] == [1]
+    assert compute_stress_binary(sample["transcription"], sample["emphasis_indices"]) == [0, 1]
+
+
+def test_emphassess_keeps_internal_apostrophe(tmp_path):
+    write_wav(tmp_path / "item.wav")
+    sample = adapt_emphassess_row({"id": "item", "src_sentence": ["today's", "plan", "."], "gold_emphasis": [0]}, tmp_path)
+    assert sample["transcription"] == "today's plan"
+
+
+def test_emphassess_filters_punctuation_emphasis(tmp_path):
+    with pytest.raises(InvalidEmphasisError):
+        adapt_emphassess_row({"id": "item", "src_sentence": ["hello", "!"], "gold_emphasis": [1]}, tmp_path)
+
+
+def test_emphassess_audio_path_uses_flat_layout(tmp_path):
+    write_wav(tmp_path / "item.wav")
+    sample = adapt_emphassess_row({"id": "item", "src_sentence": ["hello"], "gold_emphasis": []}, tmp_path)
+    assert sample["audio"]["path"] == str(tmp_path / "item.wav")
+
+
+def test_missing_audio_detection(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        adapt_emphassess_row({"id": "missing", "src_sentence": ["hello"], "gold_emphasis": []}, tmp_path)
+
+
+def test_duplicate_id_detection(tmp_path):
+    row = {"id": "same", "src_sentence": ["hello"], "gold_emphasis": []}
+    (tmp_path / "gold_df.json").write_text(json.dumps(row) + "\n" + json.dumps(row) + "\n")
+    write_wav(tmp_path / "same.wav")
+    with pytest.raises(ValueError, match="Duplicate"):
+        validate_emphassess_directory(tmp_path, require_official_counts=False)
+
+
+def test_invalid_audio_format_detection(tmp_path):
+    row = {"id": "item", "src_sentence": ["hello"], "gold_emphasis": []}
+    (tmp_path / "gold_df.json").write_text(json.dumps(row) + "\n")
+    with wave.open(str(tmp_path / "item.wav"), "wb") as wav_file:
+        wav_file.setnchannels(2)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16000)
+        wav_file.writeframes(b"\x00\x00" * 4)
+    with pytest.raises(ValueError, match="mono PCM16"):
+        validate_emphassess_directory(tmp_path, require_official_counts=False)
+
+
+def test_canonical_index_range_validation():
+    with pytest.raises(ValueError, match="out-of-range"):
+        validate_canonical_sample({"id": "bad", "transcription": "one word", "emphasis_indices": [2]})

--- a/utils.py
+++ b/utils.py
@@ -17,6 +17,7 @@ from torch.nn.utils.rnn import pad_sequence
 
 from whistress.inference_client.utils import prepare_audio, save_model_parts, get_loaded_model
 from whistress.model.model import WhiStress
+from corpora import compute_stress_binary
 
 import os
 from pathlib import Path
@@ -116,10 +117,6 @@ def add_phone_features(transcription, phone_dict):
             print(transcription)
 
     return phones, phone_ids, phone_stress
-
-def compute_stress_binary(transcription: str, emphasis_indices: list[int]) -> list[int]:
-    words = transcription.strip().split()
-    return [1 if i in emphasis_indices else 0 for i in range(len(words))]
 
 def preprocess(example, model, phone_dict):
     # 1. word-level binary label
@@ -233,7 +230,8 @@ class StressDataset(torch.utils.data.Dataset):
             "phones": item["phones"],
             "phone_ids": torch.tensor(item["phone_ids"], dtype=torch.long),
             "phone_labels_head": torch.tensor(item["phone_labels_head"], dtype=torch.long),
-            "id": item["id"]
+            "id": item["id"],
+            "source_dataset": item.get("source_dataset", "unknown")
         }
 
 @dataclass


### PR DESCRIPTION
### Motivation
- Enable evaluation across multiple stress/emphasis corpora (`tinystress`, `stresstest`, `stresspresso`, and `emphassess`) with a single, reproducible pipeline. 
- Canonicalize and validate heterogeneous dataset formats (especially EmphAssess) and ensure consistent audio/label shapes for the existing training/evaluation code. 
- Automate fetching and validation of external corpora and integrate multi-stage evaluation into the existing `run.sh` workflow.

### Description
- Add `corpora.py` which provides adapters and validators for the supported corpora, canonicalizes sample shape, remaps EmphAssess punctuation-based tokens, validates WAV formats, and exposes `load_corpus`, `compute_stress_binary`, and `validate_emphassess_directory`.
- Add `local/download_corpora.py` to download HF-hosted corpora and the official EmphAssess tarball, with safe extraction and strict validation, and to persist a normalized flat layout.
- Update `evaluation_example.py` to accept `--corpus`, `--split`, and `--data_root`, use `load_corpus`, add coverage reporting for skipped samples, and include corpus-level stats in the JSON output.
- Update `test.py` and `run.sh` to support per-corpus Stage 2 (teacher-forced token metrics) and Stage 3 (word-level evaluation) runs, and produce per-corpus result directories and `stage2_metrics.json` files.
- Modify `utils.py` to reuse `compute_stress_binary` from `corpora.py` and to carry `source_dataset` through the dataset items for downstream reporting.
- Add `tests/test_corpora.py` unit tests covering the adapters, EmphAssess remapping/filtering, WAV validation, and canonical sample checks, and update `README.md` with multi-corpus evaluation instructions and output paths.

### Testing
- Ran unit tests with `pytest tests/test_corpora.py`, which exercise adapters, EmphAssess validation/remapping, and WAV format checks, and they passed. 
- Executed the Stage 2 evaluation script to generate token-level metrics for a downloaded corpus using `python test.py` (produces `stage2_metrics.json`) as a smoke check of the pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ef2a51988832aa4fbf097bf6c06c9)