### PR TITLE
Add POS bias modules and WhiStressPos / WhiStressPhnPos models with data & inference wiring

### DIFF
--- a/conf/baseline_pos_gated.json
+++ b/conf/baseline_pos_gated.json
@@ -1,0 +1,21 @@
+[
+  {
+    "epochs": 20,
+    "batch_size": 16,
+    "init_lr": 0.0001,
+    "patience": -1,
+    "accumulate_gradient_steps": 1
+  },
+  {
+    "whisper_tag": "openai/whisper-small.en",
+    "layer_for_head": 9,
+    "model_type": "WhiStressPos",
+    "loss_lambdas": null,
+    "pos_bias_config": {
+      "mode": "gated",
+      "num_pos": 17,
+      "scale": 1.0,
+      "dropout": 0.0
+    }
+  }
+]

--- a/conf/baseline_pos_static.json
+++ b/conf/baseline_pos_static.json
@@ -1,0 +1,21 @@
+[
+  {
+    "epochs": 20,
+    "batch_size": 16,
+    "init_lr": 0.0001,
+    "patience": -1,
+    "accumulate_gradient_steps": 1
+  },
+  {
+    "whisper_tag": "openai/whisper-small.en",
+    "layer_for_head": 9,
+    "model_type": "WhiStressPos",
+    "loss_lambdas": null,
+    "pos_bias_config": {
+      "mode": "static",
+      "num_pos": 17,
+      "scale": 1.0,
+      "dropout": 0.0
+    }
+  }
+]

--- a/conf/wordstress_pos_gated.json
+++ b/conf/wordstress_pos_gated.json
@@ -1,0 +1,25 @@
+[
+  {
+    "epochs": 20,
+    "batch_size": 16,
+    "init_lr": 0.0001,
+    "patience": -1,
+    "accumulate_gradient_steps": 1
+  },
+  {
+    "whisper_tag": "openai/whisper-small.en",
+    "layer_for_head": 9,
+    "model_type": "WhiStressPhnPos",
+    "loss_lambdas": {
+      "lambda_ssd": 1.0,
+      "lambda_wsd": 1.0,
+      "lambda_wsl": -1
+    },
+    "pos_bias_config": {
+      "mode": "gated",
+      "num_pos": 17,
+      "scale": 1.0,
+      "dropout": 0.0
+    }
+  }
+]

--- a/conf/wordstress_pos_static.json
+++ b/conf/wordstress_pos_static.json
@@ -1,0 +1,25 @@
+[
+  {
+    "epochs": 20,
+    "batch_size": 16,
+    "init_lr": 0.0001,
+    "patience": -1,
+    "accumulate_gradient_steps": 1
+  },
+  {
+    "whisper_tag": "openai/whisper-small.en",
+    "layer_for_head": 9,
+    "model_type": "WhiStressPhnPos",
+    "loss_lambdas": {
+      "lambda_ssd": 1.0,
+      "lambda_wsd": 1.0,
+      "lambda_wsl": -1
+    },
+    "pos_bias_config": {
+      "mode": "static",
+      "num_pos": 17,
+      "scale": 1.0,
+      "dropout": 0.0
+    }
+  }
+]

--- a/test.py
+++ b/test.py
@@ -67,6 +67,7 @@ if __name__ == "__main__":
             labels = batch["labels_head"].to(device)
             phone_ids = batch["phone_ids"].to(device)
             phone_labels_head = batch["phone_labels_head"].to(device)
+            token_pos_ids = batch["token_pos_ids"].to(device)
             word_ids = batch["word_ids"].to(device)
 
             output = model(
@@ -75,6 +76,7 @@ if __name__ == "__main__":
                 labels_head=labels, 
                 phone_ids=phone_ids, 
                 phone_labels_head=phone_labels_head,
+                token_pos_ids=token_pos_ids,
                 word_ids=word_ids)
             
             preds = output.preds.view(-1).tolist()

--- a/train.py
+++ b/train.py
@@ -17,7 +17,13 @@ import torch.nn.functional as F
 from torch.nn.utils.rnn import pad_sequence
 
 from whistress.inference_client.utils import prepare_audio, save_model_parts, get_loaded_model
-from whistress.model.model import WhiStress, WhiStressPhn, WhiStressPhnIa
+from whistress.model.model import (
+    WhiStress,
+    WhiStressPos,
+    WhiStressPhn,
+    WhiStressPhnPos,
+    WhiStressPhnIa,
+)
 
 from utils import StressDataset, MyCollate, load_from_json, save_to_json
 from metrics import compute_prf_metrics
@@ -48,6 +54,7 @@ if __name__ == "__main__":
     whisper_tag = model_args["whisper_tag"]
     loss_lambdas = model_args["loss_lambdas"]
     layer_for_head = model_args["layer_for_head"]
+    pos_bias_config = model_args.get("pos_bias_config", None)
     #wandb.init(project="whistress", name=args.exp_dir, config=vars(args), mode="online")
 
     ckpt_dir = os.path.join(exp_dir, "checkpoints")
@@ -80,6 +87,8 @@ if __name__ == "__main__":
         "layer_for_head": layer_for_head,
         "whisper_tag": whisper_tag
     }
+    if model_type in ["WhiStressPos", "WhiStressPhnPos"]:
+        hyper_params["pos_bias_config"] = pos_bias_config
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     config = WhisperConfig.from_pretrained(whisper_tag)
@@ -90,6 +99,13 @@ if __name__ == "__main__":
                     layer_for_head=layer_for_head, 
                     whisper_backbone_name=whisper_tag,
                     loss_lambdas=loss_lambdas).to(device)
+    elif model_type == "WhiStressPos":
+        print("Train WhiStressPos")
+        model = WhiStressPos(config=config,
+                    layer_for_head=layer_for_head,
+                    whisper_backbone_name=whisper_tag,
+                    loss_lambdas=loss_lambdas,
+                    pos_bias_config=pos_bias_config).to(device)
     elif model_type == "WhiStressPhn":
         print("Train WhiStressPhn")
         model = WhiStressPhn(config=config, 
@@ -104,6 +120,14 @@ if __name__ == "__main__":
                     whisper_backbone_name=whisper_tag, 
                     num_phones=39,
                     loss_lambdas=loss_lambdas).to(device)
+    elif model_type == "WhiStressPhnPos":
+        print("Train WhiStressPhnPos")
+        model = WhiStressPhnPos(config=config,
+                    layer_for_head=layer_for_head,
+                    whisper_backbone_name=whisper_tag,
+                    num_phones=39,
+                    loss_lambdas=loss_lambdas,
+                    pos_bias_config=pos_bias_config).to(device)
     else:
         raise ValueError(f"model_type {model_type} hasn't been implemented yet.")
 
@@ -142,6 +166,7 @@ if __name__ == "__main__":
             labels = batch["labels_head"].to(device)
             phone_ids = batch["phone_ids"].to(device)
             phone_labels_head = batch["phone_labels_head"].to(device)
+            token_pos_ids = batch["token_pos_ids"].to(device)
             word_ids = batch["word_ids"].to(device)
 
             output = model(
@@ -150,6 +175,7 @@ if __name__ == "__main__":
                         labels_head=labels, 
                         phone_ids=phone_ids, 
                         phone_labels_head=phone_labels_head,
+                        token_pos_ids=token_pos_ids,
                         word_ids=word_ids
                     )
             loss_main = output.loss_main
@@ -194,6 +220,7 @@ if __name__ == "__main__":
                 labels = batch["labels_head"].to(device)
                 phone_ids = batch["phone_ids"].to(device)
                 phone_labels_head = batch["phone_labels_head"].to(device)
+                token_pos_ids = batch["token_pos_ids"].to(device)
                 word_ids = batch["word_ids"].to(device)
 
                 output = model(
@@ -202,6 +229,7 @@ if __name__ == "__main__":
                         labels_head=labels, 
                         phone_ids=phone_ids, 
                         phone_labels_head=phone_labels_head,
+                        token_pos_ids=token_pos_ids,
                         word_ids=word_ids
                     )
 

--- a/utils.py
+++ b/utils.py
@@ -158,6 +158,7 @@ def preprocess(example, model, phone_dict):
     for token in decoded_tokens:
         if token in model.processor.tokenizer.all_special_tokens:
             token_labels.append(-100)
+            token_pos.append(-1)
             continue
 
         if token.startswith(" ") or first_real_token:  # new word
@@ -175,6 +176,9 @@ def preprocess(example, model, phone_dict):
 
     # 5. LEFT SHIFT → align label with logits[t] = prediction of token[t+1]
     token_labels = token_labels[1:] + [-100]
+    token_pos = token_pos[1:] + [-1]
+    assert len(input_ids) == len(token_labels)
+    assert len(input_ids) == len(token_pos)
     
     # 6. Get phone sequence from transcription
     phones, phone_ids, phone_labels_head = add_phone_features(transcription, phone_dict)

--- a/whistress/inference_client/utils.py
+++ b/whistress/inference_client/utils.py
@@ -4,7 +4,13 @@ import librosa
 import numpy as np
 import pathlib
 from torch.nn import functional as F
-from ..model import WhiStress, WhiStressPhn, WhiStressPhnIa
+from ..model import (
+    WhiStress,
+    WhiStressPos,
+    WhiStressPhn,
+    WhiStressPhnPos,
+    WhiStressPhnIa,
+)
 import os
 import json
 
@@ -47,6 +53,23 @@ def get_loaded_model(device="cuda", metadata=None):
             whisper_backbone_name=whisper_model_name,
             num_phones=39, 
         ).to(device)
+    elif model_type == "WhiStressPos":
+        print("Inference WhiStressPos")
+        whistress_model = WhiStressPos(
+            config=whisper_config,
+            layer_for_head=layer_for_head,
+            whisper_backbone_name=whisper_model_name,
+            pos_bias_config=metadata["pos_bias_config"],
+        ).to(device)
+    elif model_type == "WhiStressPhnPos":
+        print("Inference WhiStressPhnPos")
+        whistress_model = WhiStressPhnPos(
+            config=whisper_config,
+            layer_for_head=layer_for_head,
+            whisper_backbone_name=whisper_model_name,
+            num_phones=39,
+            pos_bias_config=metadata["pos_bias_config"],
+        ).to(device)
     elif model_type == "WhiStressPhnIa":
         print("Inference WhiStressPhnIa")
         whistress_model = WhiStressPhnIa(
@@ -67,7 +90,9 @@ def get_loaded_model(device="cuda", metadata=None):
     if metadata is None:
         whistress_model.load_model(PATH_TO_WEIGHTS)
     else:
-        if model_type in ["WhiStressPhn", "WhiStressPhnIa"]:
+        if model_type in [
+            "WhiStressPos", "WhiStressPhn", "WhiStressPhnPos", "WhiStressPhnIa"
+        ]:
             print("Load All Weights")
             whistress_model.load_state_dict(torch.load(os.path.join(metadata["path_to_weights"], "model.pt")))
         else:

--- a/whistress/model/__init__.py
+++ b/whistress/model/__init__.py
@@ -1,1 +1,7 @@
-from .model import WhiStress, WhiStressPhn, WhiStressPhnIa
+from .model import (
+    WhiStress,
+    WhiStressPos,
+    WhiStressPhn,
+    WhiStressPhnPos,
+    WhiStressPhnIa,
+)

--- a/whistress/model/model.py
+++ b/whistress/model/model.py
@@ -63,6 +63,41 @@ class FCNN(nn.Module):
         return x
 
 
+class PosBias(nn.Module):
+    def __init__(self, d_model, pos_bias_config):
+        super().__init__()
+        self.mode = pos_bias_config["mode"]
+        if self.mode not in ["static", "gated"]:
+            raise ValueError(f"Unsupported POS bias mode: {self.mode}")
+        self.pos_scale = pos_bias_config["scale"]
+        self.pos_embed = nn.Embedding(
+            num_embeddings=pos_bias_config["num_pos"] + 1,
+            embedding_dim=d_model,
+            padding_idx=0,
+        )
+        self.pos_dropout = nn.Dropout(pos_bias_config["dropout"])
+        self.pos_gate = (
+            nn.Linear(2 * d_model, d_model) if self.mode == "gated" else None
+        )
+
+    def forward(self, hidden_states, token_pos_ids=None):
+        if token_pos_ids is None:
+            return hidden_states
+
+        valid_pos_mask = (token_pos_ids >= 0).unsqueeze(-1)
+        pos_input_ids = token_pos_ids + 1
+        pos_embed = self.pos_embed(pos_input_ids)
+        pos_embed = self.pos_dropout(pos_embed)
+        pos_bias = pos_embed
+        if self.mode == "gated":
+            gate = torch.sigmoid(
+                self.pos_gate(torch.cat([hidden_states, pos_embed], dim=-1))
+            )
+            pos_bias = gate * pos_embed
+        pos_bias = pos_bias * valid_pos_mask
+        return hidden_states + self.pos_scale * pos_bias
+
+
 class WhiStress(PreTrainedModel):
 
     config_class = WhisperConfig
@@ -358,6 +393,103 @@ class WhiStress(PreTrainedModel):
 
     def __str__(self):
         return "WhiStress"
+
+
+class WhiStressPos(WhiStress):
+    def __init__(self, *args, pos_bias_config=None, **kwargs):
+        if pos_bias_config is None:
+            raise ValueError("pos_bias_config is required for WhiStressPos")
+        super().__init__(*args, **kwargs)
+        self.pos_bias = PosBias(self.whisper_model.config.d_model, pos_bias_config)
+
+    def forward(
+        self,
+        input_features,
+        attention_mask=None,
+        decoder_input_ids=None,
+        labels_head=None,
+        whisper_labels=None,
+        phone_ids=None,
+        phone_labels_head=None,
+        token_pos_ids=None,
+        word_ids=None
+    ):
+        device = input_features.device
+        self.whisper_model.eval()
+
+        # pass the inputs through the model
+        backbone_outputs = self.whisper_model(
+            input_features=input_features,
+            attention_mask=attention_mask,
+            decoder_input_ids=decoder_input_ids,
+            output_hidden_states=True,
+            labels=whisper_labels,
+        )
+
+        # Extract the hidden states of the last layer of the decoder
+        decoder_last_layer_hidden_states = backbone_outputs.decoder_hidden_states[
+            self.layer_for_head
+        ].to(device)
+
+        # Extract the hidden states of the layer of the encoder who encapsulates best the prosodic features
+        layer_for_head_hidden_states = backbone_outputs.encoder_hidden_states[
+            self.layer_for_head
+        ].to(device)
+        # Pass the decoder last hidden layers through the new head (decoder_block + lin cls)
+
+        additional_decoder_block_outputs = self.additional_decoder_block(
+            hidden_states=decoder_last_layer_hidden_states,
+            encoder_hidden_states=layer_for_head_hidden_states,
+        )
+        ssd_hidden_states = self.pos_bias(
+            additional_decoder_block_outputs[0].to(device), token_pos_ids
+        )
+        head_logits = self.classifier(ssd_hidden_states)
+
+        # calculate softmax
+        head_probs = F.softmax(head_logits, dim=-1)
+        preds = head_probs.argmax(dim=-1).to(device)
+        # Calculate custom loss if labels are provided
+        # sentence stress detection
+        loss = None
+        loss_main = None
+        if labels_head is not None:
+            preds = torch.where(
+                torch.isin(
+                    labels_head, torch.tensor(list([-100])).to(device)  # 50257, 50362,
+                ),
+                torch.tensor(-100),
+                preds,
+            )
+            # CrossEntropyLoss for the custom head
+            loss_main = self.loss_fct(
+                head_logits.reshape(-1, head_logits.size(-1)), labels_head.reshape(-1)
+            )
+            loss = self.lambda_ssd * loss_main
+
+        # word stress loss
+        loss_wsl = None
+        if word_ids is not None and labels_head is not None and self.lambda_wsl > 0.0:
+            loss_wsl = compute_adaptive_weighted_loss(head_logits, labels_head, word_ids)
+            loss += self.lambda_wsl * loss_wsl
+
+        return CustomPhnModelOutput(
+            logits=head_logits,
+            labels_head=labels_head,
+            whisper_logits=backbone_outputs.logits,
+            loss=loss,
+            loss_main=loss_main,
+            loss_wsl=loss_wsl,
+            preds=preds,
+        )
+
+    def train(self, mode: Optional[bool] = True):
+        super().train(mode)
+        self.pos_bias.train(mode)
+        return self
+
+    def __str__(self):
+        return "WhiStressPos"
 
 class WhiStressPhn(PreTrainedModel):
     
@@ -673,6 +805,136 @@ class WhiStressPhn(PreTrainedModel):
 
     def __str__(self):
         return "WhiStressPhn"
+
+
+class WhiStressPhnPos(WhiStressPhn):
+    def __init__(self, *args, pos_bias_config=None, **kwargs):
+        if pos_bias_config is None:
+            raise ValueError("pos_bias_config is required for WhiStressPhnPos")
+        super().__init__(*args, **kwargs)
+        self.pos_bias = PosBias(self.whisper_model.config.d_model, pos_bias_config)
+
+    def forward(
+        self,
+        input_features,
+        attention_mask=None,
+        decoder_input_ids=None,
+        labels_head=None,
+        whisper_labels=None,
+        phone_ids=None,
+        phone_labels_head=None,
+        token_pos_ids=None,
+        word_ids=None
+    ):
+        if phone_ids is None:
+            raise ValueError("phone_ids is required for WhiStressPhn.forward")
+
+        device = input_features.device
+        self.whisper_model.eval()
+
+        # pass the inputs through the model
+        backbone_outputs = self.whisper_model(
+            input_features=input_features,
+            attention_mask=attention_mask,
+            decoder_input_ids=decoder_input_ids,
+            output_hidden_states=True,
+            labels=whisper_labels,
+        )
+
+        # Extract the hidden states of the last layer of the decoder
+        decoder_last_layer_hidden_states = backbone_outputs.decoder_hidden_states[
+            self.layer_for_head
+        ].to(device)
+
+        # Extract the hidden states of the layer of the encoder who encapsulates best the prosodic features
+        layer_for_head_hidden_states = backbone_outputs.encoder_hidden_states[
+            self.layer_for_head
+        ].to(device)
+        # Pass the decoder last hidden layers through the new head (decoder_block + lin cls)
+        additional_decoder_block_outputs = self.additional_decoder_block(
+            hidden_states=decoder_last_layer_hidden_states,
+            encoder_hidden_states=layer_for_head_hidden_states,
+        )[0].to(device)
+
+        # pass the phone_ids through the embed layer
+        phone_embed = self.phone_embed(phone_ids + 1)
+        phone_decoder_block_outputs = self.phone_decoder(
+                                        tgt=phone_embed,           # [B, T_phone, D]
+                                        memory=layer_for_head_hidden_states  # [B, T_src, D]
+                                        )
+
+        # Sentence stress detection
+        ssd_hidden_states = self.pos_bias(
+            additional_decoder_block_outputs, token_pos_ids
+        )
+        head_logits = self.classifier(ssd_hidden_states)
+        head_probs = F.softmax(head_logits, dim=-1)
+        preds = head_probs.argmax(dim=-1).to(device)
+
+        # Word stress detection
+        phone_stress_logits = self.phone_stress_classifier(phone_decoder_block_outputs)
+        phone_stress_probs = F.softmax(phone_stress_logits, dim=-1)
+        phone_stress_preds = phone_stress_probs.argmax(dim=-1).to(device)
+
+        # Calculate custom loss if labels are provided
+        # sentence stress detection
+        loss = None
+        loss_main = None
+        if labels_head is not None:
+            preds = torch.where(
+                torch.isin(
+                    labels_head, torch.tensor(list([-100])).to(device)  # 50257, 50362,
+                ),
+                torch.tensor(-100),
+                preds,
+            )
+            # CrossEntropyLoss for the custom head
+            loss_main = self.loss_fct(
+                head_logits.reshape(-1, head_logits.size(-1)), labels_head.reshape(-1)
+            )
+            loss = self.lambda_ssd * loss_main
+
+        # word stress detection
+        loss_wsd = None
+        if phone_ids is not None and phone_labels_head is not None and self.lambda_wsd > 0.0:
+            phone_stress_preds = torch.where(
+                torch.isin(
+                        phone_labels_head, torch.tensor(list([-100])).to(device)  # 50257, 50362,
+                ),
+                torch.tensor(-100),
+                phone_stress_preds,
+            )
+            loss_wsd = self.phone_loss_fct(
+                phone_stress_logits.reshape(-1, phone_stress_logits.size(-1)), phone_labels_head.reshape(-1)
+            )
+            loss += self.lambda_wsd * loss_wsd
+
+        # word stress loss
+        loss_wsl = None
+        if word_ids is not None and labels_head is not None and self.lambda_wsl > 0.0:
+            loss_wsl = compute_adaptive_weighted_loss(head_logits, labels_head, word_ids)
+            loss += self.lambda_wsl * loss_wsl
+
+        return CustomPhnModelOutput(
+            logits=head_logits,
+            labels_head=labels_head,
+            phone_stress_logits=phone_stress_logits,
+            whisper_logits=backbone_outputs.logits,
+            loss=loss,
+            loss_main=loss_main,
+            loss_wsd=loss_wsd,
+            loss_wsl=loss_wsl,
+            preds=preds,
+            phone_stress_preds=phone_stress_preds,
+        )
+
+    def train(self, mode: Optional[bool] = True):
+        super().train(mode)
+        self.pos_bias.train(mode)
+        return self
+
+    def __str__(self):
+        return "WhiStressPhnPos"
 
 class WhiStressPhnIa(WhiStressPhn):
     


### PR DESCRIPTION
### Motivation
- Introduce a positional (POS) bias mechanism to improve sentence- and word-stress modeling by conditioning the SSD/phone heads on token-level POS information.
- Support both `static` and `gated` POS-bias modes and allow configuration via training/inference metadata.

### Description
- Add a new `PosBias` module and two model variants `WhiStressPos` and `WhiStressPhnPos` that apply POS bias before the SSD classification head and expose `pos_bias_config` to control mode/size/scale/dropout.
- Wire token-level POS IDs through preprocessing (`utils.preprocess` now emits `token_pos`), dataset/collation, `train.py`, and `test.py` where `token_pos_ids` are passed into `model(...)` calls.
- Extend `whistress.model.__init__` and `whistress.inference_client.utils.get_loaded_model` to register and instantiate the new model types and handle loading full-state weights when appropriate; update save/load metadata handling.
- Add four new example config files for gated/static POS bias variants: `conf/baseline_pos_gated.json`, `conf/baseline_pos_static.json`, `conf/wordstress_pos_gated.json`, and `conf/wordstress_pos_static.json`.

### Testing
- No automated tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c157e40ec832a9eda8ec57ee7ab64)