### PR TITLE
Support parent-checkpoint initialization and freeze policy for POS models; refactor PosBias and configs

### DIFF
--- a/conf/baseline.json
+++ b/conf/baseline.json
@@ -1,8 +1,8 @@
-[ 
+[
   {
     "epochs": 20,
     "batch_size": 16,
-    "init_lr": 1e-4,
+    "init_lr": 0.0001,
     "patience": -1,
     "accumulate_gradient_steps": 1
   },
@@ -10,6 +10,11 @@
     "whisper_tag": "openai/whisper-small.en",
     "layer_for_head": 9,
     "model_type": "WhiStress",
-    "loss_lambdas": null
+    "loss_lambdas": null,
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
+    }
   }
 ]

--- a/conf/baseline_pos_gated.json
+++ b/conf/baseline_pos_gated.json
@@ -14,8 +14,14 @@
     "pos_bias_config": {
       "mode": "gated",
       "num_pos": 17,
-      "scale": 1.0,
+      "embedding_dim": 64,
+      "residual_scale_init": 0.0,
       "dropout": 0.0
+    },
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
     }
   }
 ]

--- a/conf/baseline_pos_static.json
+++ b/conf/baseline_pos_static.json
@@ -14,8 +14,14 @@
     "pos_bias_config": {
       "mode": "static",
       "num_pos": 17,
-      "scale": 1.0,
+      "embedding_dim": 64,
+      "residual_scale_init": 0.0,
       "dropout": 0.0
+    },
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
     }
   }
 ]

--- a/conf/baseline_wsl.json
+++ b/conf/baseline_wsl.json
@@ -1,8 +1,8 @@
-[ 
+[
   {
     "epochs": 20,
     "batch_size": 16,
-    "init_lr": 1e-4,
+    "init_lr": 0.0001,
     "patience": -1,
     "accumulate_gradient_steps": 1
   },
@@ -10,6 +10,14 @@
     "whisper_tag": "openai/whisper-small.en",
     "layer_for_head": 9,
     "model_type": "WhiStress",
-    "loss_lambdas": {"lambda_ssd": 1.0, "lambda_wsl": 1.0}
+    "loss_lambdas": {
+      "lambda_ssd": 1.0,
+      "lambda_wsl": 1.0
+    },
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
+    }
   }
 ]

--- a/conf/wordstress.json
+++ b/conf/wordstress.json
@@ -1,8 +1,8 @@
-[ 
+[
   {
     "epochs": 20,
     "batch_size": 16,
-    "init_lr": 1e-4,
+    "init_lr": 0.0001,
     "patience": -1,
     "accumulate_gradient_steps": 1
   },
@@ -10,6 +10,15 @@
     "whisper_tag": "openai/whisper-small.en",
     "layer_for_head": 9,
     "model_type": "WhiStressPhn",
-    "loss_lambdas": {"lambda_ssd": 1.0, "lambda_wsd": 1.0, "lambda_wsl": -1}
+    "loss_lambdas": {
+      "lambda_ssd": 1.0,
+      "lambda_wsd": 1.0,
+      "lambda_wsl": -1
+    },
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
+    }
   }
 ]

--- a/conf/wordstress_ia.json
+++ b/conf/wordstress_ia.json
@@ -1,8 +1,8 @@
-[ 
+[
   {
     "epochs": 20,
     "batch_size": 16,
-    "init_lr": 1e-4,
+    "init_lr": 0.0001,
     "patience": -1,
     "accumulate_gradient_steps": 1
   },
@@ -10,6 +10,15 @@
     "whisper_tag": "openai/whisper-small.en",
     "layer_for_head": 9,
     "model_type": "WhiStressPhnIa",
-    "loss_lambdas": {"lambda_ssd": 1.0, "lambda_wsd": 1.0, "lambda_wsl": -1}
+    "loss_lambdas": {
+      "lambda_ssd": 1.0,
+      "lambda_wsd": 1.0,
+      "lambda_wsl": -1
+    },
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
+    }
   }
 ]

--- a/conf/wordstress_pos_gated.json
+++ b/conf/wordstress_pos_gated.json
@@ -18,8 +18,14 @@
     "pos_bias_config": {
       "mode": "gated",
       "num_pos": 17,
-      "scale": 1.0,
+      "embedding_dim": 64,
+      "residual_scale_init": 0.0,
       "dropout": 0.0
+    },
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
     }
   }
 ]

--- a/conf/wordstress_pos_static.json
+++ b/conf/wordstress_pos_static.json
@@ -18,8 +18,14 @@
     "pos_bias_config": {
       "mode": "static",
       "num_pos": 17,
-      "scale": 1.0,
+      "embedding_dim": 64,
+      "residual_scale_init": 0.0,
       "dropout": 0.0
+    },
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
     }
   }
 ]

--- a/conf/wordstress_wsl.json
+++ b/conf/wordstress_wsl.json
@@ -1,8 +1,8 @@
-[ 
+[
   {
     "epochs": 20,
     "batch_size": 16,
-    "init_lr": 1e-4,
+    "init_lr": 0.0001,
     "patience": -1,
     "accumulate_gradient_steps": 1
   },
@@ -10,6 +10,15 @@
     "whisper_tag": "openai/whisper-small.en",
     "layer_for_head": 9,
     "model_type": "WhiStressPhn",
-    "loss_lambdas": {"lambda_ssd": 1.0, "lambda_wsd": 1.0, "lambda_wsl": 1.0}
+    "loss_lambdas": {
+      "lambda_ssd": 1.0,
+      "lambda_wsd": 1.0,
+      "lambda_wsl": 1.0
+    },
+    "initialization_config": {
+      "train_from_scratch": true,
+      "checkpoint_dir": null,
+      "freeze_pretrained_heads": false
+    }
   }
 ]

--- a/train.py
+++ b/train.py
@@ -55,6 +55,7 @@ if __name__ == "__main__":
     loss_lambdas = model_args["loss_lambdas"]
     layer_for_head = model_args["layer_for_head"]
     pos_bias_config = model_args.get("pos_bias_config", None)
+    initialization_config = model_args.get("initialization_config", {})
     #wandb.init(project="whistress", name=args.exp_dir, config=vars(args), mode="online")
 
     ckpt_dir = os.path.join(exp_dir, "checkpoints")
@@ -89,6 +90,31 @@ if __name__ == "__main__":
     }
     if model_type in ["WhiStressPos", "WhiStressPhnPos"]:
         hyper_params["pos_bias_config"] = pos_bias_config
+        hyper_params["initialization_config"] = initialization_config
+
+    is_pos_model = model_type in ["WhiStressPos", "WhiStressPhnPos"]
+    train_from_scratch = initialization_config.get("train_from_scratch", True)
+    parent_checkpoint_dir = initialization_config.get("checkpoint_dir")
+    freeze_pretrained_heads = initialization_config.get(
+        "freeze_pretrained_heads", False
+    )
+    # A resume restores the complete POS experiment and intentionally ignores
+    # parent-initialization settings recorded for experiment provenance.
+    if is_pos_model and not args.resume:
+        if train_from_scratch:
+            if parent_checkpoint_dir is not None:
+                raise ValueError(
+                    "checkpoint_dir must be null when train_from_scratch=True"
+                )
+            if freeze_pretrained_heads:
+                raise ValueError(
+                    "freeze_pretrained_heads must be false when "
+                    "train_from_scratch=True"
+                )
+        elif parent_checkpoint_dir is None:
+            raise ValueError(
+                "checkpoint_dir is required when train_from_scratch=False"
+            )
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     config = WhisperConfig.from_pretrained(whisper_tag)
@@ -105,7 +131,8 @@ if __name__ == "__main__":
                     layer_for_head=layer_for_head,
                     whisper_backbone_name=whisper_tag,
                     loss_lambdas=loss_lambdas,
-                    pos_bias_config=pos_bias_config).to(device)
+                    pos_bias_config=pos_bias_config,
+                    freeze_pretrained_heads=freeze_pretrained_heads).to(device)
     elif model_type == "WhiStressPhn":
         print("Train WhiStressPhn")
         model = WhiStressPhn(config=config, 
@@ -127,7 +154,8 @@ if __name__ == "__main__":
                     whisper_backbone_name=whisper_tag,
                     num_phones=39,
                     loss_lambdas=loss_lambdas,
-                    pos_bias_config=pos_bias_config).to(device)
+                    pos_bias_config=pos_bias_config,
+                    freeze_pretrained_heads=freeze_pretrained_heads).to(device)
     else:
         raise ValueError(f"model_type {model_type} hasn't been implemented yet.")
 
@@ -137,10 +165,51 @@ if __name__ == "__main__":
         "labels_head",
     ]
 
-    if args.resume and (pretrained_ckpt_dir / "model.pt").exists():
-        model.load_state_dict(torch.load(pretrained_ckpt_dir / "model.pt"))
+    if args.resume:
+        if not args.pretrained_ckpt_dir:
+            raise ValueError("--pretrained_ckpt_dir is required with --resume")
+        resume_model_path = pretrained_ckpt_dir / "model.pt"
+        if not resume_model_path.exists():
+            raise ValueError(f"Resume checkpoint not found: {resume_model_path}")
+        model.load_state_dict(torch.load(resume_model_path, map_location=device))
+    elif is_pos_model and not train_from_scratch:
+        parent_checkpoint_dir = Path(parent_checkpoint_dir)
+        metadata_path = parent_checkpoint_dir / "metadata.json"
+        model_path = parent_checkpoint_dir / "model.pt"
+        if not metadata_path.exists() or not model_path.exists():
+            raise ValueError(
+                f"checkpoint_dir must contain model.pt and metadata.json: "
+                f"{parent_checkpoint_dir}"
+            )
+        with open(metadata_path, "r") as fn:
+            parent_metadata = json.load(fn)
+        expected_parent_type = {
+            "WhiStressPos": "WhiStress",
+            "WhiStressPhnPos": "WhiStressPhn",
+        }[model_type]
+        if parent_metadata.get("model_type") != expected_parent_type:
+            raise ValueError(
+                f"{model_type} requires a {expected_parent_type} checkpoint, "
+                f"got {parent_metadata.get('model_type')}"
+            )
+        state_dict = torch.load(model_path, map_location=device)
+        load_result = model.load_state_dict(state_dict, strict=False)
+        invalid_missing_keys = [
+            key for key in load_result.missing_keys
+            if not key.startswith("pos_bias.")
+        ]
+        if invalid_missing_keys or load_result.unexpected_keys:
+            raise ValueError(
+                "Incompatible parent checkpoint: "
+                f"missing_keys={load_result.missing_keys}, "
+                f"unexpected_keys={load_result.unexpected_keys}"
+            )
 
-    optimizer = AdamW(model.parameters(), lr=init_lr)
+    # Enforce the configured freeze policy before selecting optimizer parameters.
+    model.train()
+    optimizer = AdamW(
+        [param for param in model.parameters() if param.requires_grad], lr=init_lr
+    )
 
     dataset = load_dataset("slprl/TinyStress-15K")
     raw_train_dataset = dataset["train"].train_test_split(test_size=0.1, seed=seed)

--- a/whistress/model/model.py
+++ b/whistress/model/model.py
@@ -69,12 +69,16 @@ class PosBias(nn.Module):
         self.mode = pos_bias_config["mode"]
         if self.mode not in ["static", "gated"]:
             raise ValueError(f"Unsupported POS bias mode: {self.mode}")
-        self.pos_scale = pos_bias_config["scale"]
+        self.pos_embed_dim = pos_bias_config["embedding_dim"]
+        self.residual_scale = nn.Parameter(
+            torch.tensor(float(pos_bias_config["residual_scale_init"]))
+        )
         self.pos_embed = nn.Embedding(
             num_embeddings=pos_bias_config["num_pos"] + 1,
-            embedding_dim=d_model,
+            embedding_dim=self.pos_embed_dim,
             padding_idx=0,
         )
+        self.pos_proj = nn.Linear(self.pos_embed_dim, d_model, bias=False)
         self.pos_dropout = nn.Dropout(pos_bias_config["dropout"])
         self.pos_gate = (
             nn.Linear(2 * d_model, d_model) if self.mode == "gated" else None
@@ -86,7 +90,8 @@ class PosBias(nn.Module):
 
         valid_pos_mask = (token_pos_ids >= 0).unsqueeze(-1)
         pos_input_ids = token_pos_ids + 1
-        pos_embed = self.pos_embed(pos_input_ids)
+        pos_embed_low = self.pos_embed(pos_input_ids)
+        pos_embed = self.pos_proj(pos_embed_low)
         pos_embed = self.pos_dropout(pos_embed)
         pos_bias = pos_embed
         if self.mode == "gated":
@@ -95,7 +100,7 @@ class PosBias(nn.Module):
             )
             pos_bias = gate * pos_embed
         pos_bias = pos_bias * valid_pos_mask
-        return hidden_states + self.pos_scale * pos_bias
+        return hidden_states + self.residual_scale * pos_bias
 
 
 class WhiStress(PreTrainedModel):
@@ -396,11 +401,19 @@ class WhiStress(PreTrainedModel):
 
 
 class WhiStressPos(WhiStress):
-    def __init__(self, *args, pos_bias_config=None, **kwargs):
+    def __init__(self, *args, pos_bias_config=None,
+                 freeze_pretrained_heads=False, **kwargs):
         if pos_bias_config is None:
             raise ValueError("pos_bias_config is required for WhiStressPos")
         super().__init__(*args, **kwargs)
         self.pos_bias = PosBias(self.whisper_model.config.d_model, pos_bias_config)
+        self.freeze_pretrained_heads = freeze_pretrained_heads
+
+    def _freeze_pretrained_heads(self):
+        for module in [self.additional_decoder_block, self.classifier]:
+            module.eval()
+            for param in module.parameters():
+                param.requires_grad = False
 
     def forward(
         self,
@@ -485,6 +498,10 @@ class WhiStressPos(WhiStress):
 
     def train(self, mode: Optional[bool] = True):
         super().train(mode)
+        if self.freeze_pretrained_heads:
+            self._freeze_pretrained_heads()
+        for param in self.pos_bias.parameters():
+            param.requires_grad = True
         self.pos_bias.train(mode)
         return self
 
@@ -808,11 +825,26 @@ class WhiStressPhn(PreTrainedModel):
 
 
 class WhiStressPhnPos(WhiStressPhn):
-    def __init__(self, *args, pos_bias_config=None, **kwargs):
+    def __init__(self, *args, pos_bias_config=None,
+                 freeze_pretrained_heads=False, **kwargs):
         if pos_bias_config is None:
             raise ValueError("pos_bias_config is required for WhiStressPhnPos")
         super().__init__(*args, **kwargs)
         self.pos_bias = PosBias(self.whisper_model.config.d_model, pos_bias_config)
+        self.freeze_pretrained_heads = freeze_pretrained_heads
+
+    def _freeze_pretrained_heads(self):
+        modules = [
+            self.additional_decoder_block,
+            self.classifier,
+            self.phone_embed,
+            self.phone_decoder,
+            self.phone_stress_classifier,
+        ]
+        for module in modules:
+            module.eval()
+            for param in module.parameters():
+                param.requires_grad = False
 
     def forward(
         self,
@@ -930,6 +962,10 @@ class WhiStressPhnPos(WhiStressPhn):
 
     def train(self, mode: Optional[bool] = True):
         super().train(mode)
+        if self.freeze_pretrained_heads:
+            self._freeze_pretrained_heads()
+        for param in self.pos_bias.parameters():
+            param.requires_grad = True
         self.pos_bias.train(mode)
         return self
 


### PR DESCRIPTION
### Motivation
- Provide a reproducible initialization workflow for POS models that can either train from scratch or initialize from a parent checkpoint and optionally freeze previously trained heads.  
- Make POS bias parameters more flexible and stable by replacing a scalar scale with a learnable residual scale and a dedicated embedding/projection shape.  
- Harden resume and checkpoint-loading behavior to avoid silent misconfigurations when resuming experiments or importing parent checkpoints.

### Description
- Added an `initialization_config` block to multiple example configs and updated `init_lr`/`loss_lambdas` formatting in JSON files to standardize experiment provenance and enable parent checkpoint settings.  
- Extended `train.py` to parse `initialization_config`, enforce constraints for `train_from_scratch` vs `checkpoint_dir`, require `--pretrained_ckpt_dir` with `--resume`, load checkpoints with `map_location`, and initialize POS models from parent checkpoints with compatibility checks against `metadata.json`.  
- Changed optimizer construction to only include parameters where `param.requires_grad` and added logic to pass `freeze_pretrained_heads` into model constructors.  
- Refactored `PosBias` in `whistress/model/model.py` to use `embedding_dim`, `residual_scale_init` (a learnable parameter), a projection `pos_proj` from embedding dim to model dim, and removed the old scalar `scale`.  
- Added `freeze_pretrained_heads` handling to `WhiStressPos` and `WhiStressPhnPos`, including `_freeze_pretrained_heads` helpers and ensuring `pos_bias` parameters remain trainable in `train()`.

### Testing
- Ran the project's unit test suite with `pytest` and all tests completed successfully.  
- Performed a short smoke training run on the `slprl/TinyStress-15K` dataset to verify model construction, optimizer parameter selection, and both resume and parent-checkpoint initialization paths, and the run completed without errors.  
- Verified that loading a parent checkpoint with mismatched metadata raises the intended `ValueError` by automated negative test cases, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ceed33af0832a814c48cfa09860f4)