### PR TITLE
Add Expresso as a sentence-stress test corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ If you use ***WhiStress*** in your work, please cite our paper:
 
 ## Multi-corpus evaluation
 
-The evaluation pipeline supports `tinystress`, `stresstest`, `stresspresso`, and
-`emphassess`. Stage 0 downloads and validates them without changing the Stage 1
-training data or training procedure:
+The evaluation pipeline supports `tinystress`, `stresstest`, `stresspresso`,
+`expresso`, and `emphassess`. Stage 0 downloads and validates them without
+changing the Stage 1 training data or training procedure:
 
 ```bash
 python local/download_corpora.py \
   --data_root data/raw \
-  --corpora tinystress stresstest stresspresso emphassess
+  --corpora tinystress stresstest stresspresso expresso emphassess
 
 # Download, train, test, evaluate, and plot.
 ./run.sh --stage 0 --stop_stage 4 --gpuid 0 --train_conf conf/baseline.json
@@ -185,10 +185,16 @@ python local/download_corpora.py \
 TinyStress-15K already supplies `transcription`, audio, and
 `emphasis_indices`. StressTest and StressPresso supply interpretation-specific
 IDs and nested `stress_pattern` labels; their binary labels are validated during
-adaptation. EmphAssess supplies token lists and `gold_emphasis`; its original
-16-kHz source WAV (not an output of the official speech-to-speech emphasis
-transfer pipeline) is evaluated directly. All adapters produce this canonical
-shape before the existing preprocessing runs:
+adaptation. Expresso follows the SSD protocol used by WhiStress and StressTest:
+the `read` configuration is restricted to speakers `ex01` and `ex02`, and only
+samples containing at least one asterisk-marked emphasis span are retained. The
+asterisks are removed from the transcription and every word in each marked span
+is mapped to `emphasis_indices`. Expresso exposes this material in its single
+source `train` split, but it is used only as a held-out evaluation corpus here.
+EmphAssess supplies token lists and `gold_emphasis`; its original 16-kHz source
+WAV (not an output of the official speech-to-speech emphasis transfer pipeline)
+is evaluated directly. All adapters produce this canonical shape before the
+existing preprocessing runs:
 
 ```python
 {
@@ -203,9 +209,9 @@ shape before the existing preprocessing runs:
 For EmphAssess, standalone punctuation is removed while apostrophes inside words
 are retained, and emphasis indices are remapped. The 12 rows whose emphasis
 points to standalone punctuation are rejected as invalid (3,652 original, 3,640
-retained); labels are never shifted to a neighboring word. EmphAssess is
-distributed under **CC BY-NC 4.0**; review `LICENSE.md` in the downloaded corpus
-before use.
+retained); labels are never shifted to a neighboring word. Expresso and
+EmphAssess are distributed under **CC BY-NC 4.0**. Review the respective dataset
+licenses before use.
 
 Stage 2 reports teacher-forced **Whisper token-level** metrics. Stage 3 preserves
 the inference evaluation's merged **word-level** metrics, both with and without
@@ -219,5 +225,6 @@ Corpus-specific outputs are written to:
 exp/<config>/test/tinystress/
 exp/<config>/test/stresstest/
 exp/<config>/test/stresspresso/
+exp/<config>/test/expresso/
 exp/<config>/test/emphassess/
 ```

--- a/corpora.py
+++ b/corpora.py
@@ -9,7 +9,14 @@ from array import array
 from pathlib import Path
 from typing import Any
 
-SUPPORTED_CORPORA = ("tinystress", "stresstest", "stresspresso", "emphassess")
+SUPPORTED_CORPORA = (
+    "tinystress",
+    "stresstest",
+    "stresspresso",
+    "expresso",
+    "emphassess",
+)
+EXPRESSO_EVAL_SPEAKERS = frozenset(("ex01", "ex02"))
 
 
 class InvalidEmphasisError(ValueError):
@@ -76,6 +83,66 @@ def adapt_stress_benchmark_example(
     if list(pattern["binary"]) != expected_binary:
         raise ValueError(f"Stress-pattern binary mismatch for sample {sample['id']}")
     return sample
+
+
+def parse_expresso_emphasis(text: str) -> tuple[str, list[int]]:
+    """Remove Expresso's ``*...*`` markup and return stressed word indices."""
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("Expresso text must be a non-empty string")
+
+    words: list[str] = []
+    emphasis_indices: list[int] = []
+    inside_emphasis = False
+    for marked_word in text.strip().split():
+        clean_characters: list[str] = []
+        word_is_emphasized = False
+        for character in marked_word:
+            if character == "*":
+                inside_emphasis = not inside_emphasis
+                continue
+            clean_characters.append(character)
+            if inside_emphasis:
+                word_is_emphasized = True
+
+        clean_word = "".join(clean_characters)
+        # Marker-only tokens are allowed, for example ``* several words *``.
+        if not clean_word:
+            continue
+        words.append(clean_word)
+        if word_is_emphasized:
+            emphasis_indices.append(len(words) - 1)
+
+    if inside_emphasis:
+        raise ValueError(f"Unbalanced Expresso emphasis markers: {text!r}")
+    if not words:
+        raise ValueError("Expresso text contains no words after removing emphasis markers")
+    return " ".join(words), emphasis_indices
+
+
+def is_expresso_evaluation_example(text: str, speaker_id: str) -> bool:
+    """Implement the ex01/ex02, positive-stress protocol used by prior work."""
+    if speaker_id not in EXPRESSO_EVAL_SPEAKERS:
+        return False
+    _, emphasis_indices = parse_expresso_emphasis(text)
+    return bool(emphasis_indices)
+
+
+def adapt_expresso_example(example: dict[str, Any]) -> dict[str, Any]:
+    transcription, emphasis_indices = parse_expresso_emphasis(example["text"])
+    if example["speaker_id"] not in EXPRESSO_EVAL_SPEAKERS or not emphasis_indices:
+        raise ValueError(
+            "Expresso evaluation keeps only ex01/ex02 samples with at least one "
+            "asterisk-marked stressed word"
+        )
+    return validate_canonical_sample({
+        "id": str(example["id"]),
+        "transcription": transcription,
+        "audio": _canonical_audio(example["audio"]),
+        "emphasis_indices": emphasis_indices,
+        "source_dataset": "expresso",
+        "speaker_id": example["speaker_id"],
+        "style": example.get("style"),
+    })
 
 
 def _read_wav(path: Path) -> dict[str, Any]:
@@ -145,7 +212,7 @@ def _read_emphassess_rows(root: Path) -> tuple[list[dict[str, Any]], int]:
 
 
 def load_corpus(corpus: str, split: str = "test", data_root: str | Path = "data/raw"):
-    from datasets import Dataset, load_from_disk
+    from datasets import Dataset, DatasetDict, load_from_disk
 
     if corpus not in SUPPORTED_CORPORA:
         raise ValueError(f"Unsupported corpus {corpus!r}; choose from {SUPPORTED_CORPORA}")
@@ -164,9 +231,42 @@ def load_corpus(corpus: str, split: str = "test", data_root: str | Path = "data/
         return dataset
 
     stored = load_from_disk(str(root))
-    raw = stored[split] if hasattr(stored, "keys") and split in stored else stored
+    if isinstance(stored, DatasetDict):
+        if split in stored:
+            raw = stored[split]
+        elif corpus == "expresso" and list(stored.keys()) == ["train"]:
+            # The public Expresso ``read`` configuration exposes one source
+            # split. It is filtered below into the established SSD test set.
+            raw = stored["train"]
+        else:
+            raise KeyError(
+                f"Split {split!r} is unavailable for {corpus!r}; "
+                f"available splits: {list(stored.keys())}"
+            )
+    else:
+        raw = stored
     if corpus == "tinystress":
         return raw.map(adapt_tinystress_example, remove_columns=raw.column_names)
+    if corpus == "expresso":
+        num_original_samples = len(raw)
+        selected = raw.filter(
+            is_expresso_evaluation_example,
+            input_columns=["text", "speaker_id"],
+            desc="Selecting the Expresso SSD evaluation subset",
+        )
+        dataset = selected.map(
+            adapt_expresso_example,
+            remove_columns=selected.column_names,
+        )
+        dataset.info.description = json.dumps({
+            "num_original_samples": num_original_samples,
+            "num_filtered_by_protocol": num_original_samples - len(dataset),
+            "num_retained_samples": len(dataset),
+            "source_split": "train",
+            "evaluation_speakers": sorted(EXPRESSO_EVAL_SPEAKERS),
+            "requires_positive_stress": True,
+        })
+        return dataset
     return raw.map(
         lambda example: adapt_stress_benchmark_example(example, corpus),
         remove_columns=raw.column_names,

--- a/evaluation_example.py
+++ b/evaluation_example.py
@@ -216,14 +216,15 @@ if __name__ == "__main__":
         "num_filtered_invalid_emphasis": 0,
         "num_retained_samples": len(raw_dataset),
     }
-    if args.corpus == "emphassess":
+    if args.corpus in ("expresso", "emphassess"):
         corpus_stats = json.loads(raw_dataset.info.description)
 
     results = {
         "dataset": dataset_name,
         "split": split_name,
         "num_original_samples": corpus_stats["num_original_samples"],
-        "num_filtered_invalid_emphasis": corpus_stats["num_filtered_invalid_emphasis"],
+        "num_filtered_invalid_emphasis": corpus_stats.get("num_filtered_invalid_emphasis", 0),
+        "num_filtered_by_protocol": corpus_stats.get("num_filtered_by_protocol", 0),
         "num_samples": len(raw_dataset),
         "metrics": metrics,
         "metrics_wsd": ({

--- a/local/download_corpora.py
+++ b/local/download_corpora.py
@@ -21,7 +21,9 @@ HF_DATASETS = {
     "tinystress": "slprl/TinyStress-15K",
     "stresstest": "slprl/StressTest",
     "stresspresso": "slprl/StressPresso",
+    "expresso": "ylacombe/expresso",
 }
+HF_DATASET_CONFIGS = {"expresso": "read"}
 EMPHASSESS_URL = "https://dl.fbaipublicfiles.com/speech_expressivity_evaluation/EmphAssess/EmphAssess_Dataset.tar.gz"
 
 
@@ -46,7 +48,10 @@ def download_hf_corpus(corpus: str, data_root: Path, force: bool) -> None:
         return
     if force:
         shutil.rmtree(destination, ignore_errors=True)
-    dataset = load_dataset(HF_DATASETS[corpus])
+    load_kwargs = {}
+    if corpus in HF_DATASET_CONFIGS:
+        load_kwargs["name"] = HF_DATASET_CONFIGS[corpus]
+    dataset = load_dataset(HF_DATASETS[corpus], **load_kwargs)
     temporary = Path(tempfile.mkdtemp(prefix=f".{corpus}.", dir=data_root))
     try:
         dataset.save_to_disk(str(temporary))

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ stop_stage=1000
 train_conf=conf/baseline.json
 gpuid=0
 data_root=data
-test_corpora="tinystress stresstest stresspresso emphassess"
+test_corpora="tinystress stresstest stresspresso expresso emphassess"
 force_download=false
 
 . ./local/parse_options.sh

--- a/test.py
+++ b/test.py
@@ -101,5 +101,7 @@ if __name__ == "__main__":
         "num_labeled_tokens": len(all_labels),
         **prf,
     }
+    if args.corpus in ("expresso", "emphassess"):
+        metrics.update(json.loads(dataset.info.description))
     with (results_dir / "stage2_metrics.json").open("w") as file:
         json.dump(metrics, file, indent=2)

--- a/tests/test_corpora.py
+++ b/tests/test_corpora.py
@@ -6,9 +6,12 @@ import pytest
 from corpora import (
     InvalidEmphasisError,
     adapt_emphassess_row,
+    adapt_expresso_example,
     adapt_stress_benchmark_example,
     adapt_tinystress_example,
     compute_stress_binary,
+    is_expresso_evaluation_example,
+    parse_expresso_emphasis,
     validate_canonical_sample,
     validate_emphassess_directory,
 )
@@ -57,6 +60,48 @@ def test_stress_benchmark_binary_consistency():
     example["stress_pattern"]["binary"] = [1, 0, 0]
     with pytest.raises(ValueError, match="interpretation"):
         adapt_stress_benchmark_example(example, "stresstest")
+
+
+def test_expresso_adapter_removes_markers_and_maps_multiword_span():
+    sample = adapt_expresso_example({
+        "id": "ex01_default_00001",
+        "text": "Was *this element* always *there?*",
+        "speaker_id": "ex01",
+        "style": "default",
+        "audio": audio(),
+    })
+    assert sample["transcription"] == "Was this element always there?"
+    assert sample["emphasis_indices"] == [1, 2, 4]
+    assert sample["source_dataset"] == "expresso"
+
+
+def test_expresso_parser_handles_marker_only_tokens_and_external_punctuation():
+    transcription, indices = parse_expresso_emphasis("Maybe * you should * change *priorities*, okay.")
+    assert transcription == "Maybe you should change priorities, okay."
+    assert indices == [1, 2, 4]
+
+
+def test_expresso_evaluation_filter_matches_paper_protocol():
+    assert is_expresso_evaluation_example("I said *now*.", "ex01")
+    assert is_expresso_evaluation_example("I said *now*.", "ex02")
+    assert not is_expresso_evaluation_example("I said *now*.", "ex03")
+    assert not is_expresso_evaluation_example("I said it now.", "ex01")
+
+
+def test_expresso_rejects_unbalanced_markers():
+    with pytest.raises(ValueError, match="Unbalanced"):
+        parse_expresso_emphasis("I said *right now")
+
+
+def test_expresso_adapter_rejects_sample_outside_evaluation_subset():
+    with pytest.raises(ValueError, match="ex01/ex02"):
+        adapt_expresso_example({
+            "id": "ex03_default_00001",
+            "text": "I said *now*.",
+            "speaker_id": "ex03",
+            "style": "default",
+            "audio": audio(),
+        })
 
 
 def test_emphassess_punctuation_remapping(tmp_path):


### PR DESCRIPTION
## Summary

- add the `ylacombe/expresso` `read` configuration to corpus download and evaluation
- reproduce the Expresso SSD protocol used by WhiStress and StressTest by retaining only `ex01`/`ex02` samples with at least one asterisk-marked stressed word
- remove the asterisk markup while mapping single-word and multiword spans to canonical `emphasis_indices`
- include Expresso in the default Stage 0–4 pipeline and report source/filtered/retained counts
- document the source split, filtering protocol, output path, and CC BY-NC 4.0 license
- add adapter, parser, protocol-filter, punctuation, and invalid-markup tests

## Validation

- `python -m py_compile corpora.py local/download_corpora.py test.py evaluation_example.py`
- `bash -n run.sh`
- `pytest -q` — 17 passed
- in-memory `DatasetDict({"train": ...})` integration check for filtering, mapping, and corpus metadata
- verified the live Expresso schema (`audio`, `text`, `speaker_id`, `style`, `id`) and representative asterisk-marked rows